### PR TITLE
fix: clean up ci workflow secret handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-    env:
-      HUSKY: 0
 
     steps:
       - name: Checkout code
@@ -34,12 +32,6 @@ jobs:
 
       - name: Type-check
         run: npm run type-check
-
-      - name: Create .env.local file
-        run: |
-          echo "PINECONE_API_KEY=${{ secrets.PINECONE_API_KEY }}" >> .env.local
-          echo "PINECONE_INDEX_NAME=${{ secrets.PINECONE_INDEX_NAME }}" >> .env.local
-          echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> .env.local
 
       - name: Build project
         env:


### PR DESCRIPTION
This pull request includes changes to the CI workflow configuration in the `.github/workflows/ci.yml` file. The most important changes involve the removal of environment variables and steps related to creating a `.env.local` file.

Changes to CI workflow configuration:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL14-L15): Removed the `HUSKY` environment variable from the `ci` job.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL38-L43): Removed the step that creates the `.env.local` file by echoing secrets into it.

> [!Note]
> This PR is mostly experimental to figure out what is the best way to expose our environment variables within GitHub actions while also reinforcing security and ease-of-use.